### PR TITLE
Added a configuration file to allow specific .bb column naming

### DIFF
--- a/bed_config.as
+++ b/bed_config.as
@@ -1,5 +1,5 @@
-table hg18KGchr7
-"UCSC Genes for chr7 with color plus GeneSymbol and SwissProtID"
+table JASPAR_TFBSs
+"JASPAR TFBSs genome tracks"
 (
 string  chrom;		"Reference sequence chromosome or scaffold"
 uint    chromStart;	"Start position of feature on chromosome"

--- a/bed_config.as
+++ b/bed_config.as
@@ -4,7 +4,7 @@ table JASPAR_TFBSs
 string  chrom;		"Reference sequence chromosome or scaffold"
 uint    chromStart;	"Start position of feature on chromosome"
 uint    chromEnd;	"End position of feature on chromosome"
-string  name;		"Name of gene"
+string  name;		"JASPAR profile ID"
 uint    score;		"Score"
 char[1] strand;		"+ or - for strand"
 string  TFName;		"TF Name"

--- a/bed_config.as
+++ b/bed_config.as
@@ -1,0 +1,11 @@
+table hg18KGchr7
+"UCSC Genes for chr7 with color plus GeneSymbol and SwissProtID"
+(
+string  chrom;		"Reference sequence chromosome or scaffold"
+uint    chromStart;	"Start position of feature on chromosome"
+uint    chromEnd;	"End position of feature on chromosome"
+string  name;		"Name of gene"
+uint    score;		"Score"
+char[1] strand;		"+ or - for strand"
+string  TFName;		"TF Name"
+)

--- a/scans2bigBed
+++ b/scans2bigBed
@@ -121,7 +121,7 @@ LC_ALL=C sort --parallel=$THREADS --buffer-size=${MEM}G -T $DUMMY_DIR -k1,1 -k2,
 ##
 ## Create bigBed
 ##
-bedToBigBed -as="$SCRIPT_DIR/bed_config.as" -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
+bedToBigBed -maxAlloc=25000000000 -as="$SCRIPT_DIR/bed_config.as" -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
 ##
 ## Remove sorted BED file
 ##

--- a/scans2bigBed
+++ b/scans2bigBed
@@ -124,7 +124,7 @@ LC_ALL=C sort --parallel=$THREADS --buffer-size=${MEM}G -T $DUMMY_DIR -k1,1 -k2,
 ##
 ## Create bigBed
 ##
-bedToBigBed -maxAlloc=$MAX_ALLOC -as="$SCRIPT_DIR/bed_config.as" -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
+bedToBigBed -maxAlloc=$MAX_ALLOC -as="$SCRIPT_DIR/bed_config.as" -type=bed6+1 -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
 ##
 ## Remove sorted BED file
 ##

--- a/scans2bigBed
+++ b/scans2bigBed
@@ -119,7 +119,7 @@ LC_ALL=C sort --parallel=$THREADS --buffer-size=${MEM}G -T $DUMMY_DIR -k1,1 -k2,
 ##
 ## Create bigBed
 ##
-bedToBigBed -as=bed_config.as -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
+bedToBigBed -as=/opt/software/jaspar-ucsc-tracks/bed_config.as -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
 
 ##
 ## Remove sorted BED file

--- a/scans2bigBed
+++ b/scans2bigBed
@@ -95,27 +95,20 @@ GENOME=$(basename "$CHROM_SIZES" .fa.sizes)
 ##
 BED_FILE=$DUMMY_DIR/$GENOME.bed
 SORTED_BED_FILE=$DUMMY_DIR/$GENOME.sorted.bed
-VALID_CHROMS=$DUMMY_DIR/$GENOME.valid_chroms.txt
 
 ##
-## Extract valid chromosomes from chrom.sizes file
-##
-cut -f1 "$CHROM_SIZES" > "$VALID_CHROMS"
-
-##
-## Merge all TFBSs into an unsorted BED file (filtering by valid chromosomes)
+## Merge all TFBSs into an unsorted BED file
 ##
 for FILE in $INPUT_DIR/*.tsv.gz; do
     # 1. Capture the matrix ID
     MATRIX_ID=$(basename "$FILE" .tsv.gz)
     # 2. Process the file, inserting the matrix ID between columns 3 and 4,
     # and adding the TF name as the last column
-    # 3. Filter to keep only chromosomes present in chrom.sizes
     zless "$FILE" | cut -f 1-4,6-7 | \
     awk -v MATRIX_ID="$MATRIX_ID" 'BEGIN{OFS="\t"; max=1000} {
         if($5 > max){ $5 = max } # cap the value
         print $1"\t"$2"\t"$3"\t"MATRIX_ID"\t"$5"\t"$6"\t"$4
-    }' | grep -Fwf "$VALID_CHROMS" >> "$BED_FILE"
+    }' >> "$BED_FILE"
 done
 
 ##
@@ -127,11 +120,6 @@ LC_ALL=C sort --parallel=$THREADS --buffer-size=${MEM}G -T $DUMMY_DIR -k1,1 -k2,
 ## Remove BED file
 ##
 #rm $BED_FILE
-
-##
-## Remove valid chromosomes file
-##
-rm "$VALID_CHROMS"
 
 ##
 ## Create bigBed

--- a/scans2bigBed
+++ b/scans2bigBed
@@ -13,6 +13,8 @@
 SOFT="scans2bigBed"
 VERSION="2.0.1"
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 function usage {
     echo -e "usage: $SOFT -c CHROM_SIZES -i INPUT_DIR [-h]"
 }
@@ -119,8 +121,8 @@ LC_ALL=C sort --parallel=$THREADS --buffer-size=${MEM}G -T $DUMMY_DIR -k1,1 -k2,
 ##
 ## Create bigBed
 ##
-bedToBigBed -as=bed_config.as -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
-
+# bedToBigBed -as=bed_config.as -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
+bedToBigBed -as="$SCRIPT_DIR/bed_config.as" -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
 ##
 ## Remove sorted BED file
 ##

--- a/scans2bigBed
+++ b/scans2bigBed
@@ -95,20 +95,27 @@ GENOME=$(basename "$CHROM_SIZES" .fa.sizes)
 ##
 BED_FILE=$DUMMY_DIR/$GENOME.bed
 SORTED_BED_FILE=$DUMMY_DIR/$GENOME.sorted.bed
+VALID_CHROMS=$DUMMY_DIR/$GENOME.valid_chroms.txt
 
 ##
-## Merge all TFBSs into an unsorted BED file
+## Extract valid chromosomes from chrom.sizes file
+##
+cut -f1 "$CHROM_SIZES" > "$VALID_CHROMS"
+
+##
+## Merge all TFBSs into an unsorted BED file (filtering by valid chromosomes)
 ##
 for FILE in $INPUT_DIR/*.tsv.gz; do
     # 1. Capture the matrix ID
     MATRIX_ID=$(basename "$FILE" .tsv.gz)
     # 2. Process the file, inserting the matrix ID between columns 3 and 4,
     # and adding the TF name as the last column
+    # 3. Filter to keep only chromosomes present in chrom.sizes
     zless "$FILE" | cut -f 1-4,6-7 | \
     awk -v MATRIX_ID="$MATRIX_ID" 'BEGIN{OFS="\t"; max=1000} {
         if($5 > max){ $5 = max } # cap the value
         print $1"\t"$2"\t"$3"\t"MATRIX_ID"\t"$5"\t"$6"\t"$4
-    }' >> "$BED_FILE"
+    }' | grep -Fwf "$VALID_CHROMS" >> "$BED_FILE"
 done
 
 ##
@@ -120,6 +127,11 @@ LC_ALL=C sort --parallel=$THREADS --buffer-size=${MEM}G -T $DUMMY_DIR -k1,1 -k2,
 ## Remove BED file
 ##
 #rm $BED_FILE
+
+##
+## Remove valid chromosomes file
+##
+rm "$VALID_CHROMS"
 
 ##
 ## Create bigBed

--- a/scans2bigBed
+++ b/scans2bigBed
@@ -119,7 +119,7 @@ LC_ALL=C sort --parallel=$THREADS --buffer-size=${MEM}G -T $DUMMY_DIR -k1,1 -k2,
 ##
 ## Create bigBed
 ##
-bedToBigBed -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
+bedToBigBed -as=bed_config.as -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
 
 ##
 ## Remove sorted BED file

--- a/scans2bigBed
+++ b/scans2bigBed
@@ -119,7 +119,7 @@ LC_ALL=C sort --parallel=$THREADS --buffer-size=${MEM}G -T $DUMMY_DIR -k1,1 -k2,
 ##
 ## Create bigBed
 ##
-bedToBigBed -as=/opt/software/jaspar-ucsc-tracks/bed_config.as -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
+bedToBigBed -as=bed_config.as -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
 
 ##
 ## Remove sorted BED file

--- a/scans2bigBed
+++ b/scans2bigBed
@@ -28,6 +28,7 @@ function help {
     echo 
     echo "optional arguments:"
     echo "  -h, --help          show this help message and exit"
+    echo "  -a MAX_ALLOC        max memory allocation for bedToBigBed (default = 25000000000)"
     echo "  -d DUMMY_DIR        dummy directory (default = /tmp/)"
     echo "  -m MEM              memory to use (in Gb; default = 4)"
     echo "  -o OUT_FILE         output file (default = ./bigBed.bb)"
@@ -51,6 +52,7 @@ function opts_error {
 ##################### Inputs #####################
 
 DUMMY_DIR=/tmp
+MAX_ALLOC=25000000000
 OUT_FILE=./bigBed.bb
 THREADS=1
 
@@ -60,11 +62,12 @@ then
     exit
 fi
 
-while getopts ":c:i:d:m:o:t:vh" OPT
+while getopts ":c:i:a:d:m:o:t:vh" OPT
 do
     case $OPT in
 	c) CHROM_SIZES=$OPTARG;;
 	i) INPUT_DIR=$OPTARG;;
+	a) MAX_ALLOC=$OPTARG;;
 	d) DUMMY_DIR=$OPTARG;;
 	m) MEM=$OPTARG;;
 	o) OUT_FILE=$OPTARG;;
@@ -121,7 +124,7 @@ LC_ALL=C sort --parallel=$THREADS --buffer-size=${MEM}G -T $DUMMY_DIR -k1,1 -k2,
 ##
 ## Create bigBed
 ##
-bedToBigBed -maxAlloc=25000000000 -as="$SCRIPT_DIR/bed_config.as" -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
+bedToBigBed -maxAlloc=$MAX_ALLOC -as="$SCRIPT_DIR/bed_config.as" -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
 ##
 ## Remove sorted BED file
 ##

--- a/scans2bigBed
+++ b/scans2bigBed
@@ -121,7 +121,6 @@ LC_ALL=C sort --parallel=$THREADS --buffer-size=${MEM}G -T $DUMMY_DIR -k1,1 -k2,
 ##
 ## Create bigBed
 ##
-# bedToBigBed -as=bed_config.as -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
 bedToBigBed -as="$SCRIPT_DIR/bed_config.as" -type=bed6+1 -extraIndex=TFName -tab $SORTED_BED_FILE $CHROM_SIZES $OUT_FILE
 ##
 ## Remove sorted BED file


### PR DESCRIPTION
TFName field was recently added in the track files (`.bb`). However, then the extra column gets an undefined column name. To rename the columns, we have to use a modified `.as`. file. I added that file and changes the `bedToBigBed` command in `scans2bigBed` to take that file as a parameter.